### PR TITLE
chore: GitHub Actionsの設定を更新し、Node.jsのバージョンを23.11.0に固定

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: package.json
+          node-version: 23.11.0
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: Install Node Dependencies

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "Collaborative-document-editing-tools",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "23.11.0"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Node.jsのバージョンを「23.11.0」に固定しました。
  - `package.json`にNode.jsバージョン要件を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->