### PR TITLE
fix

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,11 +1,9 @@
 name: Deploy Storybook to GitHub Pages
 
-# on:
-#   push:
-#     branches:
-#       - main
-
-on: pull_request
+on:
+  push:
+    branches:
+      - main
 
 env:
   WORKING_DIRECTORY: .

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,9 +1,11 @@
 name: Deploy Storybook to GitHub Pages
 
-on:
-  push:
-    branches:
-      - main
+# on:
+#   push:
+#     branches:
+#       - main
+
+on: pull_request
 
 env:
   WORKING_DIRECTORY: .
@@ -16,15 +18,12 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: oven-sh/setup-bun@v2
         with:
-          node-version: 20.x
-          cache: "bun"
+          bun-version: 1.2.2
           cache-dependency-path: "**/package-lock.json"
-      - name: Install Node Dependencies
-        run: bun ci
+      - name: Install Bun Dependencies
+        run: bun install
       - name: Build storybook
         run: bun run build-storybook
       - name: Upload Documents

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -17,15 +17,18 @@ jobs:
       run:
         working-directory: ${{ env.WORKING_DIRECTORY }}
     steps:
-      - name: Checkout code
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.2.2
-          cache-dependency-path: "**/package-lock.json"
-      - name: Install Bun Dependencies
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v1
+
+      - name: Install dependencies
         run: bun install
+
       - name: Build storybook
         run: bun run build-storybook
+
       - name: Upload Documents
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - StorybookのGitHub Pagesへのデプロイワークフローが、mainブランチへのpush時ではなくプルリクエスト時に実行されるようになりました。
  - Node.js環境のセットアップからBun環境のセットアップに変更されました。
  - 依存関係のインストールコマンドが`bun ci`から`bun install`に変更されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->